### PR TITLE
add_field_short_description_author

### DIFF
--- a/bundle/fields/uesio/cms/author/short_description
+++ b/bundle/fields/uesio/cms/author/short_description
@@ -1,0 +1,3 @@
+name: short_description
+label: Short Description
+type: TEXT


### PR DESCRIPTION
# What does this PR do?

Add a field called short_description to the author collection
